### PR TITLE
Chore/improv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 WORKDIR /openrm
 
-RUN mkdir /backups
+RUN mkdir -p /var/tmp/backups
+RUN chmod 777 -R /var/tmp/backups
 ADD script.sh /openrm/script.sh
 
-VOLUME /backups
+VOLUME /var/tmp/backups
 
 ENTRYPOINT ["/openrm/script.sh"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This container is meant to be used as a cronjob with Kubernetes.
 The service account running the container needs to have write access to the destination bucket, as this container makes use of `gsutil`.
 
 # Volumes
-You can mount a volume on `/backups` if you want to collect the intermediate archives, or give more space to your container for the backup process.
+You can mount a volume on `/var/tmp/backups` if you want to collect the intermediate archives, or give more space to your container for the backup process.
 
 # Cron Schedule Syntax
 

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 workdir=/tmp
 filename=$(date +'%Y%m%d-%H%M')-$RANDOM.tar.gz

--- a/script.sh
+++ b/script.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
+workdir=/tmp
 filename=$(date +'%Y%m%d-%H%M')-$RANDOM.tar.gz
 
 echo "Exporting MongoDB data as $filename"
 
-mongodump --uri ${MONGO_URI} --archive=/backups/$filename --gzip
+mongodump --uri ${MONGO_URI} --archive=$workdir/$filename --gzip
 
 echo "MongDB data exported, uploading $filename to GCS (gs://${GCS_BUCKET})"
 
-gsutil -m mv /backups/$filename gs://${GCS_BUCKET}/
+gsutil -m mv $workdir/$filename gs://${GCS_BUCKET}/
 
 echo "Archive successfully $filename uploaded to gs://${GCS_BUCKET}"
 

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-workdir=/tmp
+workdir=/var/tmp/backups
 filename=$(date +'%Y%m%d-%H%M')-$RANDOM.tar.gz
 
 echo "Exporting MongoDB data as $filename"


### PR DESCRIPTION
Needs your confirmation
- Write files in `/tmp` instead of `/backups` which requires to be run as root, which is not very good for security
- Set shell options so
  + undefined variables will be a failure
  + the program exits on the first failed line